### PR TITLE
Feature/command fix

### DIFF
--- a/components/ld2450-driver/include/ld2450.h
+++ b/components/ld2450-driver/include/ld2450.h
@@ -253,6 +253,19 @@ esp_err_t ld2450_set_region_filter(ld2450_filter_type_t type, const ld2450_regio
  */
 esp_err_t ld2450_get_region_filter(ld2450_filter_type_t *type, ld2450_region_t regions[3]);
 
+/**
+ * @brief Get the last error data buffer for debugging
+ * 
+ * This function retrieves the buffer content from the last communication error
+ * to help diagnose protocol issues.
+ * 
+ * @param buffer Buffer to copy the error data into
+ * @param buffer_size Size of the provided buffer
+ * @param length Pointer to store the actual length of error data
+ * @return esp_err_t ESP_OK on success, error code otherwise
+ */
+esp_err_t ld2450_get_last_error_data(uint8_t *buffer, size_t buffer_size, size_t *length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/ld2450-driver/src/ld2450_config.c
+++ b/components/ld2450-driver/src/ld2450_config.c
@@ -33,31 +33,57 @@ static const char *TAG = LD2450_LOG_TAG;
 static size_t build_command_packet(ld2450_state_t *instance, ld2450_cmd_t cmd, 
                                   const void *value, size_t value_len)
 {
-    size_t idx = 0;
+    uint8_t *buffer = instance->cmd_buffer;
     
-    // Add header
-    memcpy(&instance->cmd_buffer[idx], LD2450_CONFIG_FRAME_HEADER, 4);
-    idx += 4;
+    // Use direct 32-bit writes for header when possible
+    *(uint32_t*)buffer = *(uint32_t*)LD2450_CONFIG_FRAME_HEADER;
     
     // Add data length (command word (2 bytes) + value length)
-    instance->cmd_buffer[idx++] = (value_len + 2) & 0xFF;
-    instance->cmd_buffer[idx++] = ((value_len + 2) >> 8) & 0xFF;
+    buffer[4] = (value_len + 2) & 0xFF;
+    buffer[5] = ((value_len + 2) >> 8) & 0xFF;
     
     // Add command word (little-endian)
-    instance->cmd_buffer[idx++] = cmd & 0xFF;
-    instance->cmd_buffer[idx++] = (cmd >> 8) & 0xFF;
+    buffer[6] = cmd & 0xFF;
+    buffer[7] = (cmd >> 8) & 0xFF;
     
     // Add command value if present
     if (value != NULL && value_len > 0) {
-        memcpy(&instance->cmd_buffer[idx], value, value_len);
-        idx += value_len;
+        memcpy(&buffer[8], value, value_len);
     }
     
     // Add footer
-    memcpy(&instance->cmd_buffer[idx], LD2450_CONFIG_FRAME_FOOTER, 4);
-    idx += 4;
+    *(uint32_t*)&buffer[8 + value_len] = *(uint32_t*)LD2450_CONFIG_FRAME_FOOTER;
     
-    return idx;
+    return 8 + value_len + 4;
+}
+
+/**
+ * @brief Get the last error data buffer for debugging
+ */
+esp_err_t ld2450_get_last_error_data(uint8_t *buffer, size_t buffer_size, size_t *length) {
+    ld2450_state_t *instance = ld2450_get_instance();
+    
+    if (!instance || !instance->initialized || !buffer || !length) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    
+    if (xSemaphoreTake(instance->mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+    
+    size_t copy_len = instance->error_buffer_len;
+    if (copy_len > buffer_size) {
+        copy_len = buffer_size;
+    }
+    
+    if (copy_len > 0) {
+        memcpy(buffer, instance->error_buffer, copy_len);
+    }
+    
+    *length = copy_len;
+    
+    xSemaphoreGive(instance->mutex);
+    return ESP_OK;
 }
 
 /**
@@ -92,6 +118,12 @@ esp_err_t ld2450_send_command(ld2450_cmd_t cmd, const void *value, size_t value_
     // Clear UART RX buffer before sending command
     uart_flush(instance->uart_port);
     
+    // Clear UART event queue to ensure no old events interfere
+    uart_event_t event;
+    while (xQueueReceive(instance->uart_queue, &event, 0) == pdTRUE) {
+        // Just drain the queue
+    }
+    
     // Send the command
     int bytes_sent = uart_write_bytes(instance->uart_port, (const char *)instance->cmd_buffer, cmd_len);
     if (bytes_sent != cmd_len) {
@@ -104,31 +136,63 @@ esp_err_t ld2450_send_command(ld2450_cmd_t cmd, const void *value, size_t value_
     ESP_LOG_BUFFER_HEX_LEVEL(TAG, instance->cmd_buffer, cmd_len, ESP_LOG_VERBOSE);
     
     // Wait for ACK response
-    uint8_t byte_buf;
-    int idx = 0;
     bool found_header = false;
     bool found_footer = false;
+    bool found_cmd_echo = false;
+    int idx = 0;
+    
+    // Use a queue-based approach to check for events
     TickType_t start_time = xTaskGetTickCount();
     TickType_t timeout_ticks = pdMS_TO_TICKS(timeout_ms);
     
     while ((xTaskGetTickCount() - start_time) < timeout_ticks && idx < LD2450_ACK_BUFFER_SIZE) {
-        int bytes_read = uart_read_bytes(instance->uart_port, &byte_buf, 1, 10 / portTICK_PERIOD_MS);
-        if (bytes_read == 1) {
-            instance->ack_buffer[idx] = byte_buf;
-            idx++;
-            
-            // Check for header
-            if (idx >= 4 && !found_header) {
-                if (memcmp(instance->ack_buffer, LD2450_CONFIG_FRAME_HEADER, 4) == 0) {
-                    found_header = true;
-                }
-            }
-            
-            // Check for footer once we have a header
-            if (found_header && idx >= 8) {  // Header + min data size + footer
-                if (memcmp(&instance->ack_buffer[idx - 4], LD2450_CONFIG_FRAME_FOOTER, 4) == 0) {
-                    found_footer = true;
-                    break;
+        // Wait for UART event with timeout
+        if (xQueueReceive(instance->uart_queue, &event, pdMS_TO_TICKS(10)) == pdTRUE) {
+            if (event.type == UART_DATA) {
+                // Read available data
+                int bytes_to_read = MIN(event.size, LD2450_ACK_BUFFER_SIZE - idx);
+                int bytes_read = uart_read_bytes(instance->uart_port, 
+                                                &instance->ack_buffer[idx], 
+                                                bytes_to_read, 
+                                                pdMS_TO_TICKS(10));
+                
+                if (bytes_read > 0) {
+                    // Check for radar data frame header and skip it - this is crucial!
+                    if (!found_header && idx + bytes_read >= 4) {
+                        // Check if we got a radar data frame instead of config ACK
+                        if (memcmp(instance->ack_buffer, LD2450_DATA_FRAME_HEADER, 4) == 0) {
+                            ESP_LOGW(TAG, "Received radar data frame instead of ACK, skipping");
+                            idx = 0; // Reset buffer, this isn't our ACK
+                            continue;
+                        }
+                    }
+                    
+                    idx += bytes_read;
+                    
+                    // Look for config header
+                    if (!found_header && idx >= 4) {
+                        if (memcmp(instance->ack_buffer, LD2450_CONFIG_FRAME_HEADER, 4) == 0) {
+                            found_header = true;
+                            ESP_LOGV(TAG, "Found ACK header");
+                        }
+                    }
+                    
+                    // Look for command echo
+                    if (found_header && !found_cmd_echo && idx >= 8) {
+                        if (instance->ack_buffer[6] == (cmd & 0xFF) && instance->ack_buffer[7] == 0x01) {
+                            found_cmd_echo = true;
+                            ESP_LOGV(TAG, "Found command echo in ACK");
+                        }
+                    }
+                    
+                    // Look for footer
+                    if (found_header && idx >= 12) { // Minimum ACK size with header, length, command, status and footer
+                        if (memcmp(&instance->ack_buffer[idx-4], LD2450_CONFIG_FRAME_FOOTER, 4) == 0) {
+                            found_footer = true;
+                            ESP_LOGV(TAG, "Found ACK footer");
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -136,9 +200,15 @@ esp_err_t ld2450_send_command(ld2450_cmd_t cmd, const void *value, size_t value_
     
     if (!found_header || !found_footer) {
         ESP_LOGE(TAG, "Failed to receive complete ACK for command %04x (got %d bytes)", cmd, idx);
+        
+        // Store error data for debugging
+        instance->error_buffer_len = idx > LD2450_ERROR_BUFFER_SIZE ? 
+                                     LD2450_ERROR_BUFFER_SIZE : idx;
         if (idx > 0) {
+            memcpy(instance->error_buffer, instance->ack_buffer, instance->error_buffer_len);
             ESP_LOG_BUFFER_HEX_LEVEL(TAG, instance->ack_buffer, idx, ESP_LOG_DEBUG);
         }
+        
         xSemaphoreGive(instance->mutex);
         return ESP_ERR_TIMEOUT;
     }
@@ -216,16 +286,26 @@ esp_err_t ld2450_enter_config_mode(void)
         return ESP_OK;
     }
     
+    // Set config mode flag first to pause normal data processing
+    instance->in_config_mode = true;
+    
+    // Allow time for processing task to respect the flag
+    vTaskDelay(pdMS_TO_TICKS(50));
+    
+    // Flush any pending data in UART buffer
+    uart_flush(instance->uart_port);
+    
     // Command value: 0x0001 (little-endian)
     uint8_t value[2] = {0x01, 0x00};
     esp_err_t ret = ld2450_send_command(LD2450_CMD_ENABLE_CONFIG, value, sizeof(value), 
                                        NULL, NULL, LD2450_CONFIG_TIMEOUT_MS);
     
     if (ret == ESP_OK) {
-        instance->in_config_mode = true;
         ESP_LOGI(TAG, "Entered configuration mode");
     } else {
         ESP_LOGE(TAG, "Failed to enter configuration mode: %s", esp_err_to_name(ret));
+        // Revert config mode flag on failure
+        instance->in_config_mode = false;
     }
     
     return ret;

--- a/components/ld2450-driver/src/ld2450_private.h
+++ b/components/ld2450-driver/src/ld2450_private.h
@@ -45,11 +45,14 @@ extern "C" {
 /** @brief Timeout for module restart in milliseconds */
 #define LD2450_RESTART_TIMEOUT_MS 3000
 
-/** @brief Size of the UART RX buffer (replaces CONFIG_LD2450_UART_RX_BUF_SIZE) */
-#define LD2450_UART_RX_BUF_SIZE 512
+/** @brief Size of the UART RX buffer */
+#define LD2450_UART_RX_BUF_SIZE 1024  // Increased from 512
 
 /** @brief Stack size for the processing task (replaces CONFIG_LD2450_TASK_STACK_SIZE) */
 #define LD2450_TASK_STACK_SIZE 4096
+
+/** @brief Error debug data buffer size */
+#define LD2450_ERROR_BUFFER_SIZE 256
 
 /** @brief MIN macro for getting minimum of two values */
 #ifndef MIN
@@ -67,6 +70,14 @@ static const uint8_t LD2450_DATA_FRAME_FOOTER[] = {0x55, 0xCC};
 static const uint8_t LD2450_CONFIG_FRAME_HEADER[] = {0xFD, 0xFC, 0xFB, 0xFA};
 /** @brief Config frame footer (0x04, 0x03, 0x02, 0x01) */
 static const uint8_t LD2450_CONFIG_FRAME_FOOTER[] = {0x04, 0x03, 0x02, 0x01};
+
+/**
+ * @brief Union for efficient frame header detection
+ */
+typedef union {
+    uint32_t value;
+    uint8_t bytes[4];
+} frame_header_t;
 
 /**
  * @brief Command words defined in the protocol
@@ -138,6 +149,10 @@ typedef struct {
     uint16_t frame_idx;
     /** @brief Frame synchronization state */
     bool frame_synced;
+    uint32_t idle_count;  // Counter for adaptive task delay
+    /** @brief Error debug data */
+    uint8_t error_buffer[LD2450_ERROR_BUFFER_SIZE];
+    size_t error_buffer_len;
 } ld2450_state_t;
 
 /**
@@ -192,9 +207,10 @@ void ld2450_processing_task(void *arg);
 /**
  * @brief UART event handler
  * 
- * @param event UART event data
+ * @param data_buffer Buffer containing UART data
+ * @param len Length of data in the buffer
  */
-void ld2450_uart_event_handler(void *arg);
+void ld2450_uart_event_handler(uint8_t *data_buffer, size_t len);
 
 /**
  * @brief Get driver instance (singleton)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,5 @@
 idf_component_register(
-    SRCS "ld2450_example.c"
-    INCLUDE_DIRS ""
-    REQUIRES nvs_flash driver esp_timer ld2450-driver console
-    # PRIV_REQUIRES spi_flash
+    SRCS "ld2450_test.c"
+    INCLUDE_DIRS "."
+    REQUIRES "ld2450-driver"
 )

--- a/main/ld2450_example.c
+++ b/main/ld2450_example.c
@@ -149,7 +149,7 @@
      
      // Configure radar with example settings
      vTaskDelay(pdMS_TO_TICKS(1000));  // Give the radar some time to initialize
-     configure_radar();
+    //  configure_radar();
      
      // Main loop - display radar data every 3 seconds
      while (1) {

--- a/main/ld2450_test.c
+++ b/main/ld2450_test.c
@@ -1,0 +1,235 @@
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>  // Added for PRIu16, PRIu32 macros
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "ld2450.h"
+
+static const char *TAG = "LD2450_TEST";
+
+// Utility function to print buffer as hex dump
+void print_hex_dump(const char* prefix, const uint8_t* data, size_t len) {
+    if (!data || len == 0) {
+        ESP_LOGI(TAG, "%s: <empty buffer>", prefix);
+        return;
+    }
+    
+    ESP_LOGI(TAG, "%s (%u bytes):", prefix, len);
+    
+    char line[128];
+    char *ptr = line;
+    
+    for (size_t i = 0; i < len; i++) {
+        if (i % 16 == 0) {
+            if (i > 0) {
+                *ptr = '\0';
+                ESP_LOGI(TAG, "%s", line);
+            }
+            ptr = line;
+            ptr += sprintf(ptr, "  %04x: ", (unsigned int)i);
+        }
+        
+        ptr += sprintf(ptr, "%02x ", data[i]);
+        
+        // Add extra space after 8 bytes for readability
+        if ((i % 16 == 7)) {
+            ptr += sprintf(ptr, " ");
+        }
+    }
+    
+    // Print any remaining bytes
+    if (ptr != line) {
+        *ptr = '\0';
+        ESP_LOGI(TAG, "%s", line);
+    }
+}
+
+// Function to retrieve and print error debug info from driver
+void print_error_debug_info(void) {
+    uint8_t debug_buffer[256];
+    size_t debug_len = 0;
+    
+    esp_err_t ret = ld2450_get_last_error_data(debug_buffer, sizeof(debug_buffer), &debug_len);
+    if (ret == ESP_OK && debug_len > 0) {
+        print_hex_dump("Last error data", debug_buffer, debug_len);
+    } else {
+        ESP_LOGI(TAG, "No error debug data available");
+    }
+}
+
+// Callback function to handle radar detection data
+static void radar_data_callback(const ld2450_frame_t *frame, void *user_ctx) {
+    if (!frame) return;
+    
+    ESP_LOGI(TAG, "---------- Radar Data Frame ----------");
+    ESP_LOGI(TAG, "Timestamp: %lld ms", frame->timestamp / 1000);
+    ESP_LOGI(TAG, "Number of targets detected: %d", frame->count);
+    
+    for (int i = 0; i < frame->count; i++) {
+        const ld2450_target_t *target = &frame->targets[i];
+        if (target->valid) {
+            ESP_LOGI(TAG, "Target #%d:", i + 1);
+            ESP_LOGI(TAG, "  Position:   (%d, %d) mm", target->x, target->y);
+            ESP_LOGI(TAG, "  Distance:   %.2f mm", target->distance);
+            ESP_LOGI(TAG, "  Angle:      %.1f°", target->angle);
+            ESP_LOGI(TAG, "  Speed:      %d cm/s", target->speed);
+            ESP_LOGI(TAG, "  Resolution: %d mm", target->resolution);
+        }
+    }
+    ESP_LOGI(TAG, "--------------------------------------\n");
+}
+
+void print_mac_address(uint8_t mac[6]) {
+    ESP_LOGI(TAG, "MAC Address: %02X:%02X:%02X:%02X:%02X:%02X", 
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+void print_region_filter(ld2450_filter_type_t type, ld2450_region_t regions[3]) {
+    const char *type_str = "Unknown";
+    switch (type) {
+        case LD2450_FILTER_DISABLED: type_str = "Disabled"; break;
+        case LD2450_FILTER_INCLUDE_ONLY: type_str = "Include Only"; break;
+        case LD2450_FILTER_EXCLUDE: type_str = "Exclude"; break;
+    }
+    
+    ESP_LOGI(TAG, "Region Filter: %s", type_str);
+    if (type != LD2450_FILTER_DISABLED) {
+        for (int i = 0; i < 3; i++) {
+            ESP_LOGI(TAG, "  Region %d: (%d,%d) to (%d,%d) mm", 
+                    i+1, regions[i].x1, regions[i].y1, regions[i].x2, regions[i].y2);
+        }
+    }
+}
+
+void app_main(void) {
+    ESP_LOGI(TAG, "Starting LD2450 Radar Test");
+    
+    // Initialize LD2450 with default configuration
+    ld2450_config_t config = LD2450_DEFAULT_CONFIG();
+    
+    // Print configuration settings
+    ESP_LOGI(TAG, "Initializing LD2450 with:");
+    ESP_LOGI(TAG, "  UART Port: %d", config.uart_port);
+    ESP_LOGI(TAG, "  RX Pin: GPIO%d", config.uart_rx_pin);
+    ESP_LOGI(TAG, "  TX Pin: GPIO%d", config.uart_tx_pin);
+    ESP_LOGI(TAG, "  Baud Rate: %lu", config.uart_baud_rate);
+    ESP_LOGI(TAG, "  Auto Processing: %s", config.auto_processing ? "Enabled" : "Disabled");
+    
+    esp_err_t ret = ld2450_init(&config);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize LD2450! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+        return;
+    }
+    ESP_LOGI(TAG, "LD2450 initialized successfully");
+    
+    // Register callback for target data
+    ret = ld2450_register_target_callback(radar_data_callback, NULL);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register callback! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+        return;
+    }
+    
+    // Configure the radar
+    ESP_LOGI(TAG, "Configuring radar settings...");
+    
+    // 1. Enable Bluetooth
+    ret = ld2450_set_bluetooth(true);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to enable Bluetooth! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+    } else {
+        ESP_LOGI(TAG, "Bluetooth enabled successfully");
+    }
+    
+    // 2. Set tracking mode to multi-target
+    ret = ld2450_set_tracking_mode(LD2450_MODE_MULTI_TARGET);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set tracking mode! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+    } else {
+        ESP_LOGI(TAG, "Tracking mode set to multi-target");
+    }
+    
+    // 3. Disable area filtering
+    ld2450_region_t empty_regions[3] = {0};
+    ret = ld2450_set_region_filter(LD2450_FILTER_DISABLED, empty_regions);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to disable area filtering! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+    } else {
+        ESP_LOGI(TAG, "Area filtering disabled");
+    }
+    
+    // 4. Restart radar module
+    ESP_LOGI(TAG, "Restarting radar module...");
+    ret = ld2450_restart_module();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to restart module! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+    }
+    
+    // Wait for the module to restart
+    vTaskDelay(pdMS_TO_TICKS(3000));
+    ESP_LOGI(TAG, "Radar module restarted");
+    
+    // 5. Get configuration information
+    ESP_LOGI(TAG, "\n======== RADAR CONFIGURATION ========");
+    
+    // Get firmware version
+    ld2450_firmware_version_t version;
+    ret = ld2450_get_firmware_version(&version);
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "Firmware: %s (Main: %" PRIu16 ", Sub: %" PRIu32 ")", 
+                 version.version_string, version.main_version, version.sub_version);
+    } else {
+        ESP_LOGE(TAG, "Failed to get firmware version! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+    }
+    
+    // Get MAC address
+    uint8_t mac[6];
+    ret = ld2450_get_mac_address(mac);
+    if (ret == ESP_OK) {
+        print_mac_address(mac);
+    } else {
+        ESP_LOGE(TAG, "Failed to get MAC address! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+    }
+    
+    // Get tracking mode
+    ld2450_tracking_mode_t mode;
+    ret = ld2450_get_tracking_mode(&mode);
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "Tracking Mode: %s", 
+                 mode == LD2450_MODE_SINGLE_TARGET ? "Single Target" : "Multi Target");
+    } else {
+        ESP_LOGE(TAG, "Failed to get tracking mode! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+    }
+    
+    // Get region filter configuration
+    ld2450_filter_type_t filter_type;
+    ld2450_region_t regions[3];
+    ret = ld2450_get_region_filter(&filter_type, regions);
+    if (ret == ESP_OK) {
+        print_region_filter(filter_type, regions);
+    } else {
+        ESP_LOGE(TAG, "Failed to get region filter! Error: %s", esp_err_to_name(ret));
+        print_error_debug_info();
+    }
+    
+    ESP_LOGI(TAG, "===================================\n");
+    
+    // Wait for and process radar data
+    ESP_LOGI(TAG, "Waiting for radar detection data...");
+    ESP_LOGI(TAG, "(Press Ctrl+C to exit)");
+    
+    // Main loop - the callback will handle incoming data
+    while (1) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}


### PR DESCRIPTION
---

### Branch Merge Description

This merge includes two key commits focused on improving reliability and usability of the LD2450 radar driver application:

1. **Fix Race Condition Between Data Processing and Configuration Command Handling**

   - Reworked `ld2450_enter_config_mode()` to set a configuration mode flag *before* sending commands, preventing interference from the data processing task during ACK reception.
   - Introduced a short delay to ensure the processing task has time to respect the new mode flag.
   - Enhanced `ld2450_send_command()` to clear the UART event queue before sending commands, reducing the risk of stale data interfering with command acknowledgments.
   - Implemented logic to detect and ignore radar data frames during ACK reception, preventing misinterpretation of frames as ACKs.
   - Updated the processing task to completely skip data processing in configuration mode, using an early `continue` statement.
   - Added detailed logging in the UART event handler for improved debugging while in config mode.

   These changes collectively resolve the race condition, ensuring reliable communication during configuration commands.

2. **Improve Radar Display Timing and Add Boot Button Exit**

   - Modified radar display logic to print frames only every 3 seconds, reducing console spam while preserving frame processing.
   - Added a double-press exit mechanism via the boot button (GPIO0):
     - Configured GPIO0 with internal pull-up and attached an ISR to detect presses.
     - Implemented timing logic to detect double presses within 500ms.
     - On double press, set a global `g_exit_app` flag to trigger graceful shutdown.
   - The main loop now checks this flag and exits cleanly, deinitializing components.

   These enhancements improve usability during debugging and provide a user-friendly way to exit the test application.

--- 